### PR TITLE
Run and report status

### DIFF
--- a/src/components/home/PromoSection.tsx
+++ b/src/components/home/PromoSection.tsx
@@ -13,11 +13,7 @@ const PromoSection: React.FC = () => {
   
   const promoContent = getSectionById('promo');
   
-  // Don't render if section is hidden
-  if (!promoContent?.visible) {
-    return null;
-  }
-
+  // Ensure hooks are always called in the same order across renders
   useEffect(() => {
     const timer = setInterval(() => {
       setTimeLeft(prev => {
@@ -40,6 +36,11 @@ const PromoSection: React.FC = () => {
 
     return () => clearInterval(timer);
   }, []);
+  
+  // Don't render if section is hidden
+  if (!promoContent?.visible) {
+    return null;
+  }
 
   return (
     <section className="py-16 relative overflow-hidden">


### PR DESCRIPTION
Fixes React error #300 by moving `useEffect` above conditional return in `PromoSection.tsx`.

React error #300 ("Rendered fewer hooks than expected") occurs when hooks are conditionally called. Moving the `useEffect` ensures it's always called in the same order, resolving the issue caused by an early `return null` before the hook.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d4c0ca2-25ce-4ff9-a57e-cb9e07d0d75c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d4c0ca2-25ce-4ff9-a57e-cb9e07d0d75c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

